### PR TITLE
adaptive margin since ipad air

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -26,3 +26,7 @@ html, body{
    border-radius: 30%;
    
 }
+
+@media (max-width:820px) {
+.timer_wrapper  {margin-top: 20%}
+}


### PR DESCRIPTION
add margin for timer wrapper for adaptive version (since 820px)